### PR TITLE
fix rng normalization

### DIFF
--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -50,7 +50,7 @@ void g_random_seed(int seed) {
 
 float g_random()
 {
-	return ((rng_next_global() & 0x7fff) / ((float)0x8000));
+	return (rng_next_global() >> 8 & 0xffffff) / 16777216.0f;
 }
 
 float crandom()


### PR DESCRIPTION
old method used lower 15 bits; performs poorly on tests for randomness

new method uses upper 24 bits; performs well on tests for randomness

cannot use more than 24 bits without loss of precision during float conversion