### PR TITLE
SOCD detection

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -952,6 +952,8 @@ typedef struct gedict_s
 	float fLastSideMoveSpeed;
 	int   matchStrafeChangeCount;
 	int   matchPerfectStrafeCount;
+	int   totalStrafeChangeCount;
+	int   totalPerfectStrafeCount;
 	int   nullStrafeCount;
 // SOCD
 

--- a/include/progs.h
+++ b/include/progs.h
@@ -944,6 +944,17 @@ typedef struct gedict_s
 	float fIllegalFPSWarnings;
 // ILLEGALFPS]
 
+// SOCD detectioin
+	float fStrafeChangeCount;
+	float fFramePerfectStrafeChangeCount;
+	int   socdDetected;
+	int   socdChecksCount;
+	float fLastSideMoveSpeed;
+	int   matchStrafeChangeCount;
+	int   matchPerfectStrafeCount;
+	int   nullStrafeCount;
+// SOCD
+
 	float shownick_time;					// used to force centerprint is off at desired time
 	clientType_t ct;						// client type for client edicts
 // { timing

--- a/src/client.c
+++ b/src/client.c
@@ -1666,6 +1666,8 @@ void ClientConnect()
 	self->fLastSideMoveSpeed = 0;
 	self->matchStrafeChangeCount = 0;
 	self->matchPerfectStrafeCount = 0;
+	self->totalStrafeChangeCount = 0;
+	self->totalPerfectStrafeCount = 0;
 	self->nullStrafeCount = 0;
 
 // ILLEGALFPS[
@@ -3534,15 +3536,17 @@ void PlayerPreThink()
 
 	float fSideMoveSpeed = self->movement[1];
 
-	if ( (fSideMoveSpeed != 0) && (fSideMoveSpeed != self->fLastSideMoveSpeed) && (self->nullStrafeCount < 3) ) //strafechange
+	if ((fSideMoveSpeed != 0) && (fSideMoveSpeed != self->fLastSideMoveSpeed) && (self->nullStrafeCount < 3)) //strafechange
 	{
 		self->fStrafeChangeCount += 1;
+		self->totalStrafeChangeCount += 1;
 		if (match_in_progress)
 			self->matchStrafeChangeCount += 1;
 
 		if ((fSideMoveSpeed != 0) && (self->fLastSideMoveSpeed != 0))
 		{
 			self->fFramePerfectStrafeChangeCount += 1;
+			self->totalPerfectStrafeCount += 1;
 			if (match_in_progress)
 				self->matchPerfectStrafeCount += 1;
 		}
@@ -3566,7 +3570,7 @@ void PlayerPreThink()
 			int k_allow_socd_warning = cvar("k_allow_socd_warning");
 
 			self->socdDetected += 1;
-			if ( (!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer) ) 
+			if ((!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer))
 			{
 				G_bprint(PRINT_HIGH,
 					"Warning! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",

--- a/src/client.c
+++ b/src/client.c
@@ -1658,6 +1658,16 @@ void ClientConnect()
 		SendIntermissionToClient();
 	}
 
+// SOCD
+	self->socdChecksCount = 0;
+	self->socdDetected = 0;
+	self->fStrafeChangeCount = 0;
+	self->fFramePerfectStrafeChangeCount = 0;
+	self->fLastSideMoveSpeed = 0;
+	self->matchStrafeChangeCount = 0;
+	self->matchPerfectStrafeCount = 0;
+	self->nullStrafeCount = 0;
+
 // ILLEGALFPS[
 
 	// Zibbo's frametime checking code
@@ -3519,6 +3529,55 @@ void PlayerPreThink()
 		BotPreThink(self);
 	}
 #endif
+
+// SOCD detection
+
+	float fSideMoveSpeed = self->movement[1];
+
+	if ( (fSideMoveSpeed != 0) && (fSideMoveSpeed != self->fLastSideMoveSpeed) && (self->nullStrafeCount < 3) ) //strafechange
+	{
+		self->fStrafeChangeCount += 1;
+		if (match_in_progress)
+			self->matchStrafeChangeCount += 1;
+
+		if ((fSideMoveSpeed != 0) && (self->fLastSideMoveSpeed != 0))
+		{
+			self->fFramePerfectStrafeChangeCount += 1;
+			if (match_in_progress)
+				self->matchPerfectStrafeCount += 1;
+		}
+
+		self->nullStrafeCount = 0;
+	}
+	else
+	{
+		if (0 == fSideMoveSpeed)
+			self->nullStrafeCount += 1;
+		else
+			self->nullStrafeCount = 0;
+	}
+
+	self->fLastSideMoveSpeed = fSideMoveSpeed;
+
+	if (self->fStrafeChangeCount >= 25)
+	{
+		if (self->fFramePerfectStrafeChangeCount / self->fStrafeChangeCount >= 0.75)
+		{
+			int k_allow_socd_warning = cvar("k_allow_socd_warning");
+
+			self->socdDetected += 1;
+			if ( (!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer) ) 
+			{
+				G_bprint(PRINT_HIGH,
+					"Warning! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",
+					self->netname);
+			}
+		}
+
+		self->socdChecksCount += 1;
+		self->fStrafeChangeCount = 0;
+		self->fFramePerfectStrafeChangeCount = 0;
+	}
 
 // ILLEGALFPS[
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -8114,14 +8114,42 @@ void fcheck()
 
 	if (!is_real_adm(self))
 	{
-		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server"))
+		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server") && strneq(arg_x, "f_movement"))
 		{
 			G_sprint(self, 2, "You are not allowed to check \020%s\021\n"
-						"available checks are: f_version, f_modified and f_server\n",
+						"available checks are: f_version, f_modified, f_server and f_movement\n",
 						arg_x);
 
 			return;
 		}
+	}
+
+	if (streq(arg_x, "f_movement"))
+	{
+		G_bprint(2, "%s is checking \020%s\021\n", self->netname, arg_x);
+
+		for (i = 1; i <= MAX_CLIENTS; i++)
+		{
+			if (!strnull(g_edicts[i].netname))
+			{
+				if (g_edicts[i].socdDetected > 0)
+				{
+					G_bprint(2, "%s: SOCD movement assistance detected!\n", g_edicts[i].netname);
+				}
+				else
+				{
+					if (g_edicts[i].socdChecksCount >= 2)
+					{
+						G_bprint(2, "%s: no assistance detected.\n", g_edicts[i].netname);
+					}
+					else
+					{
+						G_bprint(2, "%s: not enough movement captured yet to run SOCD detection.\n", g_edicts[i].netname);
+					}
+				}
+			}
+		}
+		return;
 	}
 
 	for (i = 1; i <= MAX_CLIENTS; i++)

--- a/src/commands.c
+++ b/src/commands.c
@@ -8089,6 +8089,7 @@ void fcheck()
 {
 	char arg_x[1024];
 	int i;
+	gedict_t* p;
 
 	if (match_in_progress)
 	{
@@ -8128,24 +8129,21 @@ void fcheck()
 	{
 		G_bprint(2, "%s is checking \020%s\021\n", self->netname, arg_x);
 
-		for (i = 1; i <= MAX_CLIENTS; i++)
+		for (p = world; (p = find_client(p));)
 		{
-			if (!strnull(g_edicts[i].netname))
+			if ((p->ct == ctPlayer) && (!p->isBot))
 			{
-				if (g_edicts[i].socdDetected > 0)
+				if (p->socdDetected > 0)
 				{
-					G_bprint(2, "%s: SOCD movement assistance detected!\n", g_edicts[i].netname);
+					G_bprint(2, "%s: %s:%.1f%% (%d/%d). SOCD movement assistance detected!\n", p->netname, redtext("Perfect strafes"),
+						p->totalStrafeChangeCount > 0 ? 100.0 * p->totalPerfectStrafeCount / p->totalStrafeChangeCount : 0.0,
+						p->totalPerfectStrafeCount, p->totalStrafeChangeCount);
 				}
 				else
 				{
-					if (g_edicts[i].socdChecksCount >= 2)
-					{
-						G_bprint(2, "%s: no assistance detected.\n", g_edicts[i].netname);
-					}
-					else
-					{
-						G_bprint(2, "%s: not enough movement captured yet to run SOCD detection.\n", g_edicts[i].netname);
-					}
+					G_bprint(2, "%s: %s:%.1f%% (%d/%d)\n", p->netname, redtext("Perfect strafes"),
+						p->totalStrafeChangeCount > 0 ? 100.0 * p->totalPerfectStrafeCount / p->totalStrafeChangeCount : 0.0,
+						p->totalPerfectStrafeCount, p->totalStrafeChangeCount);
 				}
 			}
 		}

--- a/src/stats.c
+++ b/src/stats.c
@@ -763,9 +763,11 @@ void OnePlayerStats(gedict_t *p, int tp)
 					p->ps.vel_frames > 0 ? p->ps.velocity_sum / p->ps.vel_frames : 0.);
 	}
 
+	// movement
 	if (!p->isBot)
 	{
-		G_bprint(2, "%s: %s:%d/%d %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
+		G_bprint(2, "%s: %s:%.1f%% (%d/%d) %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
+			p->matchStrafeChangeCount > 0 ? 100.0 * p->matchPerfectStrafeCount / p->matchStrafeChangeCount : 0.0,
 			p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
 			p->socdDetected, p->socdChecksCount);
 	}

--- a/src/stats.c
+++ b/src/stats.c
@@ -763,6 +763,14 @@ void OnePlayerStats(gedict_t *p, int tp)
 					p->ps.vel_frames > 0 ? p->ps.velocity_sum / p->ps.vel_frames : 0.);
 	}
 
+	if (!p->isBot)
+	{
+		G_bprint(2, "%s: %s:%d/%d %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
+			p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
+			p->socdDetected, p->socdChecksCount);
+	}
+
+
 	// armors + megahealths
 	if (!lgc_enabled())
 	{

--- a/src/world.c
+++ b/src/world.c
@@ -1000,6 +1000,8 @@ void FirstFrame()
 
 	RegisterCvar("k_teamoverlay"); // q3 like team overlay
 
+	RegisterCvar("k_allow_socd_warning"); // socd
+
 // { SP
 	RegisterCvarEx("k_monster_spawn_time", "20");
 // }


### PR DESCRIPTION
1) Automatic warning if the server detects SOCD (can be enabled or disabled by the admin by modifying k_allow_socd_warning)
2) Command to check f_movement, summarizing for each player if the server detected anything. (ex: cmd check f_movement)
3) End-of-game stats to show if SOCD was in use.