### PR TITLE
Refine SOCD detection thresholds and reporting

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -458,6 +458,8 @@ char* clean_string(char *s);
 
 void visible_to(gedict_t *viewer, gedict_t *first, int len, byte *visible);
 
+qbool socd_movement_assisted(gedict_t *p);
+
 // Work around for the fact that QVM dos not support ".*s" in printf() family functions.
 // It retuns dots array filled with dots, amount of dots depends of how long cmd name and longest cmd name.
 char* make_dots(char *dots, size_t dots_len, int cmd_max_len, char *cmd);

--- a/include/progs.h
+++ b/include/progs.h
@@ -31,6 +31,7 @@
 #define LGCMODE_MAX_DISTANCE 700
 #define LGCMODE_DISTANCE_BUCKETS 20
 #define LGCMODE_BUCKET_DISTANCE  (LGCMODE_MAX_DISTANCE / LGCMODE_DISTANCE_BUCKETS)
+#define SOCD_DETECTION_VERSION "SOCDv2"
 
 typedef struct shared_edict_s
 {
@@ -985,8 +986,8 @@ typedef struct gedict_s
 // SOCD detectioin
 	float fStrafeChangeCount;
 	float fFramePerfectStrafeChangeCount;
-	int   socdDetected;
-	int   socdChecksCount;
+	int   socdDetectionCount;
+	int   socdValidationCount;
 	float fLastSideMoveSpeed;
 	int   matchStrafeChangeCount;
 	int   matchPerfectStrafeCount;

--- a/src/client.c
+++ b/src/client.c
@@ -1839,8 +1839,8 @@ void ClientConnect(void)
 	}
 
 // SOCD
-	self->socdChecksCount = 0;
-	self->socdDetected = 0;
+	self->socdValidationCount = 0;
+	self->socdDetectionCount = 0;
 	self->fStrafeChangeCount = 0;
 	self->fFramePerfectStrafeChangeCount = 0;
 	self->fLastSideMoveSpeed = 0;
@@ -3865,16 +3865,16 @@ void PlayerPreThink(void)
 			{
 				int k_allow_socd_warning = cvar("k_allow_socd_warning");
 
-				self->socdDetected += 1;
-				if ((!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer))
-				{
-					G_bprint(PRINT_HIGH,
-						"Warning! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",
-						self->netname);
-				}
+				self->socdDetectionCount += 1;
+				if ((!match_in_progress) && (!self->isBot) && k_allow_socd_warning && (self->ct == ctPlayer) && (self->socdDetectionCount >= 2))
+                               {
+                                       G_bprint(PRINT_HIGH,
+                                               "[%s] Warning! %s: Movement assistance detected. Please disable iDrive or keyboard strafe assistance features.\n",
+                               SOCD_DETECTION_VERSION, self->netname);
+                               }
 			}
 
-			self->socdChecksCount += 1;
+			self->socdValidationCount += 1;
 			self->fStrafeChangeCount = 0;
 			self->fFramePerfectStrafeChangeCount = 0;
 		}

--- a/src/commands.c
+++ b/src/commands.c
@@ -8435,18 +8435,11 @@ void fcheck(void)
 		{
 			if ((p->ct == ctPlayer) && (!p->isBot))
 			{
-				if (p->socdDetected > 0)
-				{
-					G_bprint(2, "%s: %s:%.1f%% (%d/%d). SOCD movement assistance detected!\n", p->netname, redtext("Perfect strafes"),
-						p->totalStrafeChangeCount > 0 ? 100.0 * p->totalPerfectStrafeCount / p->totalStrafeChangeCount : 0.0,
-						p->totalPerfectStrafeCount, p->totalStrafeChangeCount);
-				}
-				else
-				{
-					G_bprint(2, "%s: %s:%.1f%% (%d/%d)\n", p->netname, redtext("Perfect strafes"),
-						p->totalStrafeChangeCount > 0 ? 100.0 * p->totalPerfectStrafeCount / p->totalStrafeChangeCount : 0.0,
-						p->totalPerfectStrafeCount, p->totalStrafeChangeCount);
-				}
+				G_bprint(2, "[%s] %s: %s:%.1f%% (%d/%d) %s:%d/%d%s\n", SOCD_DETECTION_VERSION, p->netname, redtext("Perfect strafes"),
+					p->matchStrafeChangeCount > 0 ? 100.0 * p->matchPerfectStrafeCount / p->matchStrafeChangeCount : 0.0,
+					p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
+					p->socdDetectionCount, p->socdValidationCount,
+					socd_movement_assisted(p) ? ". SOCD movement assistance detected!" : "");
 			}
 		}
 		return;

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -2847,3 +2847,24 @@ char* make_dots(char *dots, size_t dots_len, int cmd_max_len, char *cmd)
 	dots[len] = 0;
 	return dots;
 }
+
+qbool socd_movement_assisted(gedict_t *p)
+{
+	if (p->totalStrafeChangeCount < 200 || p->socdDetectionCount < 5)
+	{
+		return false;
+	}
+
+	if ((float)p->totalPerfectStrafeCount / p->totalStrafeChangeCount > 0.58f)
+	{
+		return true;
+	}
+
+	if (p->socdValidationCount > 0 &&
+	((float)p->socdDetectionCount / p->socdValidationCount) >= 0.10f)
+	{
+		return true;
+	}
+
+	return false;
+}

--- a/src/match.c
+++ b/src/match.c
@@ -915,6 +915,16 @@ static void SM_PrepareClients(void)
 	{
 		players[player_count++] = p;
 		p->leavemealone = false;		// can't have this enabled during match
+		p->socdDetectionCount = 0;
+		p->socdValidationCount = 0;
+		p->fStrafeChangeCount = 0;
+		p->fFramePerfectStrafeChangeCount = 0;
+		p->fLastSideMoveSpeed = 0;
+		p->matchStrafeChangeCount = 0;
+		p->matchPerfectStrafeCount = 0;
+		p->totalStrafeChangeCount = 0;
+		p->totalPerfectStrafeCount = 0;
+		p->nullStrafeCount = 0;
 	}
 
 	for (i = player_count - 1; i > 0; i--)

--- a/src/stats.c
+++ b/src/stats.c
@@ -766,10 +766,11 @@ void OnePlayerStats(gedict_t *p, int tp)
 	// movement
 	if (!p->isBot)
 	{
-		G_bprint(2, "%s: %s:%.1f%% (%d/%d) %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
-			p->matchStrafeChangeCount > 0 ? 100.0 * p->matchPerfectStrafeCount / p->matchStrafeChangeCount : 0.0,
-			p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
-			p->socdDetected, p->socdChecksCount);
+			G_bprint(2, "[%s] %s: %s:%.1f%% (%d/%d) %s:%d/%d%s\n", SOCD_DETECTION_VERSION, redtext("Movement"), redtext("Perfect strafes"),
+				p->matchStrafeChangeCount > 0 ? 100.0 * p->matchPerfectStrafeCount / p->matchStrafeChangeCount : 0.0,
+				p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
+				p->socdDetectionCount, p->socdValidationCount,
+				socd_movement_assisted(p) ? ". SOCD movement assistance detected!" : "");
 	}
 
 


### PR DESCRIPTION
track SOCD detection with versioned output
reset SOCD stats on match start and separate runtime warnings
apply stricter thresholds for flagging SOCD movement assistance